### PR TITLE
Add functionality to Copy content  to another bucket 

### DIFF
--- a/src/filebrowser.ts
+++ b/src/filebrowser.ts
@@ -189,11 +189,10 @@ export const toolbarFileBrowser: JupyterFrontEndPlugin<void> = {
           ]
         }).then(result => {
           if (result.value) {
-            const { path, toDir } = args;
             S3Drive.copyToAnotherBucket(
-              path as string,
-              toDir as string,
-              result.value
+              args.path as string,
+              result.value[1] as string,
+              result.value[0]
             );
           }
         });
@@ -325,23 +324,31 @@ class CopyToAnotherBucket extends Widget {
   constructor() {
     super({ node: Private.createCopyToAnotherBucketNode() });
     this.addClass(FILE_DIALOG_CLASS);
-    const value = this.inputNode.value;
-    console.log(value);
-    this.inputNode.setSelectionRange(0, value.length);
+    const name = this.inputNameNode.value;
+    this.inputNameNode.setSelectionRange(0, name.length);
+    const location = this.inputLocationNode.value;
+    this.inputLocationNode.setSelectionRange(0, location.length);
   }
 
   /**
-   * Get the input text node.
+   * Get the input text node for the bucket name.
    */
-  get inputNode(): HTMLInputElement {
+  get inputNameNode(): HTMLInputElement {
     return this.node.getElementsByTagName('input')[0] as HTMLInputElement;
+  }
+
+  /**
+   * Get the input text node for the location within the bucket.
+   */
+  get inputLocationNode(): HTMLInputElement {
+    return this.node.getElementsByTagName('input')[1] as HTMLInputElement;
   }
 
   /**
    * Get the value of the widget.
    */
-  getValue(): string {
-    return this.inputNode.value;
+  getValue(): string[] {
+    return [this.inputNameNode.value, this.inputLocationNode.value];
   }
 }
 
@@ -448,8 +455,15 @@ namespace Private {
     nameTitle.className = SWITCH_DRIVE_TITLE_CLASS;
     const name = document.createElement('input');
 
+    const location = document.createElement('label');
+    location.textContent = 'Location within the Bucket';
+    location.className = SWITCH_DRIVE_TITLE_CLASS;
+    const locationName = document.createElement('input');
+
     body.appendChild(nameTitle);
     body.appendChild(name);
+    body.appendChild(location);
+    body.appendChild(locationName);
     return body;
   }
 }

--- a/src/filebrowser.ts
+++ b/src/filebrowser.ts
@@ -273,11 +273,12 @@ class SwitchDriveHandler extends Widget {
    */
   constructor(oldDriveName: string) {
     super({ node: Private.createSwitchDriveNode(oldDriveName) });
+    this.onAfterAttach();
+  }
+
+  protected onAfterAttach(): void {
     this.addClass(FILE_DIALOG_CLASS);
-    // const ext = PathExt.extname(oldPath);
-    // const value = (this.inputNode.value = PathExt.basename(oldPath));
     const value = this.inputNode.value;
-    console.log(value);
     this.inputNode.setSelectionRange(0, value.length);
   }
 
@@ -305,11 +306,12 @@ class NewDriveHandler extends Widget {
    */
   constructor() {
     super({ node: Private.createNewDriveNode() });
+    this.onAfterAttach();
+  }
+
+  protected onAfterAttach(): void {
     this.addClass(FILE_DIALOG_CLASS);
-    // const ext = PathExt.extname(oldPath);
-    // const value = (this.inputNode.value = PathExt.basename(oldPath));
     const value = this.inputNode.value;
-    console.log(value);
     this.inputNode.setSelectionRange(0, value.length);
   }
 
@@ -337,6 +339,10 @@ class CopyToAnotherBucket extends Widget {
    */
   constructor() {
     super({ node: Private.createCopyToAnotherBucketNode() });
+    this.onAfterAttach();
+  }
+
+  protected onAfterAttach(): void {
     this.addClass(FILE_DIALOG_CLASS);
     const name = this.inputNameNode.value;
     this.inputNameNode.setSelectionRange(0, name.length);

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -472,14 +472,13 @@ export class Drive implements Contents.IDrive {
     if (options.type !== undefined) {
       if (options.type !== 'directory') {
         const name = this.incrementUntitledName(old_data, options);
-        const response = await this.s3Client.send(
+        await this.s3Client.send(
           new PutObjectCommand({
             Bucket: this._name,
             Key: options.path ? options.path + '/' + name : name,
             Body: body
           })
         );
-        console.log('NEW FILE, response: ', response);
 
         // retrieve information of old file
         const newFileContents = await this._s3Client.send(
@@ -507,14 +506,13 @@ export class Drive implements Contents.IDrive {
       } else {
         // creating a new directory
         const name = this.incrementUntitledName(old_data, options);
-        const response = await this.s3Client.send(
+        await this.s3Client.send(
           new PutObjectCommand({
             Bucket: this._name,
             Key: options.path ? options.path + '/' + name + '/' : name + '/',
             Body: body
           })
         );
-        console.log('NEW DIRECTORY, response: ', response);
 
         data = {
           name: name,
@@ -619,13 +617,12 @@ export class Drive implements Contents.IDrive {
       isDir = 1;
     }
 
-    const response = await this.s3Client.send(
+    await this.s3Client.send(
       new DeleteObjectCommand({
         Bucket: this._name,
         Key: localPath
       })
     );
-    console.log('DELETE, response: ', response);
 
     // if we are dealing with a directory, delete files inside it
     if (isDir) {
@@ -744,14 +741,13 @@ export class Drive implements Contents.IDrive {
     const body = await fileContents.Body?.transformToString();
 
     // create new file with same content, but different name
-    const response = await this.s3Client.send(
+    await this.s3Client.send(
       new PutObjectCommand({
         Bucket: this._name,
         Key: newLocalPath,
         Body: body
       })
     );
-    console.log('RENAME, response', response);
 
     // in the case of renaming a directory, move files to new location
     if (isDir) {
@@ -932,7 +928,7 @@ export class Drive implements Contents.IDrive {
     }
 
     // save file with new content by overwritting existing file
-    const response = await this._s3Client.send(
+    await this._s3Client.send(
       new PutObjectCommand({
         Bucket: this._name,
         Key: localPath,
@@ -940,7 +936,6 @@ export class Drive implements Contents.IDrive {
         CacheControl: 'no-cache'
       })
     );
-    console.log('SAVE response: ', response);
 
     // retrieve information of file with new content
     const info = await this._s3Client.send(
@@ -991,8 +986,6 @@ export class Drive implements Contents.IDrive {
     isDir: boolean,
     bucketName: string
   ) {
-    console.log('COPIED ITEM PATH: ', copiedItemPath);
-
     // extracting original file name
     const originalFileName =
       copiedItemPath.split('/')[copiedItemPath.split('/').length - 1];
@@ -1055,14 +1048,13 @@ export class Drive implements Contents.IDrive {
     const newFileName = await this.incrementCopyName(path, isDir, this._name);
     path = isDir ? path + '/' : path;
 
-    const copy_response = await this._s3Client.send(
+    await this._s3Client.send(
       new CopyObjectCommand({
         Bucket: this._name,
         CopySource: this._name + '/' + path,
         Key: toDir !== '' ? toDir + '/' + newFileName : newFileName
       })
     );
-    console.log('COPY response: ', copy_response);
 
     // in the case of renaming a directory, move files to new location
     if (isDir) {
@@ -1165,14 +1157,13 @@ export class Drive implements Contents.IDrive {
     path = isDir ? path + '/' : path;
 
     // copy file to another bucket
-    const copy_response = await this._s3Client.send(
+    await this._s3Client.send(
       new CopyObjectCommand({
         Bucket: bucketName,
         CopySource: this._name + '/' + path,
         Key: toDir !== '' ? toDir + '/' + newFileName : newFileName
       })
     );
-    console.log('COPY response: ', copy_response);
 
     // in the case of renaming a directory, move files to new location
     if (isDir) {
@@ -1293,7 +1284,7 @@ export class Drive implements Contents.IDrive {
    * @param name bucket name
    */
   async setBucketCORS(name: string) {
-    const response = await this.s3Client.send(
+    await this.s3Client.send(
       new PutBucketCorsCommand({
         Bucket: name,
         CORSConfiguration: {
@@ -1315,7 +1306,6 @@ export class Drive implements Contents.IDrive {
         }
       })
     );
-    console.log('SET BUCKET CORS, response: ', response);
   }
 
   /**
@@ -1345,16 +1335,12 @@ export class Drive implements Contents.IDrive {
     newPath: string,
     bucketName: string
   ) {
-    const copy_response = await this._s3Client.send(
+    await this._s3Client.send(
       new CopyObjectCommand({
         Bucket: bucketName,
         CopySource: this._name + '/' + oldPath + fileName,
         Key: newPath + fileName
       })
-    );
-    console.log(
-      'RENAME or COPY, file inside directory copy resp: ',
-      copy_response
     );
   }
 
@@ -1365,13 +1351,12 @@ export class Drive implements Contents.IDrive {
    * @param filePath complete path of file to delete
    */
   private async delete_file(filePath: string) {
-    const delete_response = await this.s3Client.send(
+    await this.s3Client.send(
       new DeleteObjectCommand({
         Bucket: this._name,
         Key: filePath
       })
     );
-    console.log('DELETE, file inside directory response: ', delete_response);
   }
 
   /**


### PR DESCRIPTION
Added the functionality to copy content to another bucket, as such also updated helping renaming functions to include bucket name parameter.

[Screencast-copying-file-to-another-bucket.webm](https://github.com/QuantStack/jupyter-drives-browser/assets/91504950/91cb6f60-a3aa-4169-b590-6be3bbac7db3)

The handler nodes for the added commands (switch to another bucket, create new bucket, copy content to anot
her bucket) were also updated to use `onAfterAttach`.