### PR TITLE
Refactor contents listing

### DIFF
--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -619,7 +619,7 @@ export class Drive implements Contents.IDrive {
     // get list of contents with given prefix (path)
     const command = new ListObjectsV2Command({
       Bucket: this._name,
-      Prefix: localPath
+      Prefix: localPath.split('.').length === 1 ? localPath + '/' : localPath
     });
 
     let isTruncated: boolean | undefined = true;


### PR DESCRIPTION
Refactored the listing of contents in the `get` function by extracting the content at that directory level and displaying it. Adapted the `delete` and `copy` functionalities to work the same way - in order to eliminate corner cases brought by different file paths.