### PR TITLE
Extract config from `.env` file for dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 JP_S3_BUCKET=<S3 Bucket Name>
-JP_S3_REGION=<AWS Bucket Region>
-JP_S3_ENDPOINT=<AWS Custom Endpoint>
-JP_S3_ACCESS_KEY_ID=<AWS Access Key ID / IAM Access Key ID>
-JP_S3_SECRET_ACCESS_KEY=<AWS Secret Acccess Key / IAM Secret>
+JP_S3_REGION=<S3 Bucket Region>
+JP_S3_ENDPOINT=<S3 Custom Endpoint>
+JP_S3_ACCESS_KEY_ID=<S3 Access Key ID / IAM Access Key ID>
+JP_S3_SECRET_ACCESS_KEY=<S3 Secret Acccess Key / IAM Secret>

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-S3_BUCKET=<S3 Bucket Name>
-S3_REGION=<AWS Bucket Region>
-S3_ENDPOINT=<AWS Custom Endpoint>
-S3_ACCESS_KEY_ID=<AWS Access Key ID / IAM Access Key ID>
-S3_SECRET_ACCESS_KEY=<AWS Secret Acccess Key / IAM Secret>
+JP_S3_BUCKET=<S3 Bucket Name>
+JP_S3_REGION=<AWS Bucket Region>
+JP_S3_ENDPOINT=<AWS Custom Endpoint>
+JP_S3_ACCESS_KEY_ID=<AWS Access Key ID / IAM Access Key ID>
+JP_S3_SECRET_ACCESS_KEY=<AWS Secret Acccess Key / IAM Secret>

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+S3_BUCKET=<S3 Bucket Name>
+S3_REGION=<AWS Bucket Region>
+S3_ENDPOINT=<AWS Custom Endpoint>
+S3_ACCESS_KEY_ID=<AWS Access Key ID / IAM Access Key ID>
+S3_SECRET_ACCESS_KEY=<AWS Secret Acccess Key / IAM Secret>

--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ dmypy.json
 
 # Yarn cache
 .yarn/
+
+# Env file
+.env

--- a/dev.webpack.config.js
+++ b/dev.webpack.config.js
@@ -1,0 +1,5 @@
+const Dotenv = require('dotenv-webpack');
+
+module.exports = {
+  plugins: [new Dotenv()]
+};

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "@typescript-eslint/eslint-plugin": "^6.1.0",
         "@typescript-eslint/parser": "^6.1.0",
         "css-loader": "^6.7.1",
+        "dotenv-webpack": "^8.1.0",
         "eslint": "^8.36.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^5.0.0",
@@ -102,7 +103,8 @@
         "disabledExtensions": [
             "@jupyterlab/filebrowser-extension:default-file-browser"
         ],
-        "schemaDir": "schema"
+        "schemaDir": "schema",
+        "webpackConfig": "./dev.webpack.config.js"
     },
     "eslintIgnore": [
         "node_modules",

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,14 +83,17 @@ const authFileBrowser: JupyterFrontEndPlugin<IS3Auth> = {
   activate: (): IS3Auth => {
     return {
       factory: async () => ({
-        bucket: 'jupyter-drives-test-bucket-1',
+        bucket: process.env.S3_BUCKET ?? 'jupyter-drives-test-bucket-1',
         config: {
           forcePathStyle: true,
-          endpoint: 'https://example.com/s3',
-          region: 'eu-west-1',
+          endpoint: process.env.S3_ENDPOINT ?? 'https://example.com/s3',
+          region: process.env.S3_REGION ?? 'eu-west-1',
           credentials: {
-            accessKeyId: 'abcdefghijklmnopqrstuvwxyz',
-            secretAccessKey: 'SECRET123456789abcdefghijklmnopqrstuvwxyz'
+            accessKeyId:
+              process.env.S3_ACCESS_KEY_ID ?? 'abcdefghijklmnopqrstuvwxyz',
+            secretAccessKey:
+              process.env.S3_SECRET_ACCESS_KEY ??
+              'SECRET123456789abcdefghijklmnopqrstuvwxyz'
           }
         }
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,16 +83,16 @@ const authFileBrowser: JupyterFrontEndPlugin<IS3Auth> = {
   activate: (): IS3Auth => {
     return {
       factory: async () => ({
-        bucket: process.env.S3_BUCKET ?? 'jupyter-drives-test-bucket-1',
+        bucket: process.env.JP_S3_BUCKET ?? 'jupyter-drives-test-bucket-1',
         config: {
           forcePathStyle: true,
-          endpoint: process.env.S3_ENDPOINT ?? 'https://example.com/s3',
-          region: process.env.S3_REGION ?? 'eu-west-1',
+          endpoint: process.env.JP_S3_ENDPOINT ?? 'https://example.com/s3',
+          region: process.env.JP_S3_REGION ?? 'eu-west-1',
           credentials: {
             accessKeyId:
-              process.env.S3_ACCESS_KEY_ID ?? 'abcdefghijklmnopqrstuvwxyz',
+              process.env.JP_S3_ACCESS_KEY_ID ?? 'abcdefghijklmnopqrstuvwxyz',
             secretAccessKey:
-              process.env.S3_SECRET_ACCESS_KEY ??
+              process.env.JP_S3_SECRET_ACCESS_KEY ??
               'SECRET123456789abcdefghijklmnopqrstuvwxyz'
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6248,6 +6248,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv-defaults@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "dotenv-defaults@npm:2.0.2"
+  dependencies:
+    dotenv: ^8.2.0
+  checksum: c005960bd048e2189c4799e729c41f362e415e6e0b54313d3f31e853a84b049bf770b25cb21c112c2805bb13a8376edc9de451fb514abf8546392d327c27f6e5
+  languageName: node
+  linkType: hard
+
+"dotenv-webpack@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "dotenv-webpack@npm:8.1.0"
+  dependencies:
+    dotenv-defaults: ^2.0.2
+  peerDependencies:
+    webpack: ^4 || ^5
+  checksum: 9bb53318941b9ea39da7caf4dddd473f0e6bd3b97679fb4b853324e38841d848f8428af784e76d8efeb659f325b9cbcf420422458d635ca6fe72b9057c7c1abe
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^8.2.0":
+  version: 8.6.0
+  resolution: "dotenv@npm:8.6.0"
+  checksum: 38e902c80b0666ab59e9310a3d24ed237029a7ce34d976796349765ac96b8d769f6df19090f1f471b77a25ca391971efde8a1ea63bb83111bd8bec8e5cc9b2cd
+  languageName: node
+  linkType: hard
+
 "duplicate-package-checker-webpack-plugin@npm:^3.0.0":
   version: 3.0.0
   resolution: "duplicate-package-checker-webpack-plugin@npm:3.0.0"
@@ -8569,6 +8596,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^6.1.0
     "@typescript-eslint/parser": ^6.1.0
     css-loader: ^6.7.1
+    dotenv-webpack: ^8.1.0
     eslint: ^8.36.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: ^5.0.0


### PR DESCRIPTION
Added logic to extract config from `.env` file for development mode. 

A test file `.env.example` was added which can locally be renamed to `.env` and the values of the variables can be replaced with the needed ones. The variables that can be changed are: 
- `JP_S3_BUCKET`
- `JP_S3_REGION`
- `JP_S3_ENDPOINT`
- `JP_S3_ACCESS_KEY_ID`
- `JP_S3_SECRET_ACCESS_KEY`