### PR TITLE
Refactor awaiting S3 operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,10 +138,6 @@ const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
       }
     );
 
-    // TODO: Refactor this.
-    // add the filebrowser model to the drive
-    S3Drive.fileBrowserModel = defaultBrowser.model;
-
     Private.addCommands(app, S3Drive, fileBrowserFactory);
 
     void Private.restoreBrowser(

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -2,7 +2,6 @@ import { Signal, ISignal } from '@lumino/signaling';
 import { Contents, ServerConnection } from '@jupyterlab/services';
 import { URLExt } from '@jupyterlab/coreutils';
 import { JupyterFrontEnd } from '@jupyterlab/application';
-import { FileBrowserModel } from '@jupyterlab/filebrowser';
 
 import {
   CopyObjectCommand,
@@ -194,20 +193,6 @@ export class Drive implements Contents.IDrive {
    */
   get disposed(): ISignal<this, void> {
     return this._disposed;
-  }
-
-  /**
-   * Set the filebrowser model connected to the drive.
-   */
-  set fileBrowserModel(fileBrowserModel: FileBrowserModel) {
-    this._fileBrowserModel = fileBrowserModel;
-  }
-
-  /**
-   * Get the filebrowser model connected to the drive.
-   */
-  get fileBrowserModel(): FileBrowserModel {
-    return this._fileBrowserModel!;
   }
 
   /**
@@ -549,9 +534,6 @@ export class Drive implements Contents.IDrive {
       console.warn('Type of new element is undefined');
     }
 
-    // manually refresh filebrowser contents
-    this._fileBrowserModel!.refresh();
-
     Contents.validateContentsModel(data);
     this._fileChanged.emit({
       type: 'new',
@@ -634,19 +616,17 @@ export class Drive implements Contents.IDrive {
         await this._s3Client.send(command);
 
       if (Contents) {
-        Contents.forEach(c => {
+        const promises = Contents.map(async c => {
           // delete each file with given path
-          this.delete_file(c.Key!);
+          await this.delete_file(c.Key!);
         });
+        await Promise.all(promises);
       }
       if (isTruncated) {
         isTruncated = IsTruncated;
       }
       command.input.ContinuationToken = NextContinuationToken;
     }
-
-    // manually refresh filebrowser contents
-    this._fileBrowserModel!.refresh();
 
     this._fileChanged.emit({
       type: 'delete',
@@ -745,28 +725,25 @@ export class Drive implements Contents.IDrive {
           type: fileType
         };
 
-        Contents.forEach(c => {
+        const promises = Contents.map(async c => {
           const remainingFilePath = c.Key!.substring(oldLocalPath.length);
-          // copy each file from old directory to new location
-          this.copy_file(
+
+          await this.copy_file(
             remainingFilePath,
             oldLocalPath,
             newLocalPath,
             this._name
-          );
+          ).finally(async () => {
+            await this.delete_file(oldLocalPath + remainingFilePath);
+          });
         });
+        await Promise.all(promises);
       }
       if (isTruncated) {
         isTruncated = IsTruncated;
       }
       command.input.ContinuationToken = NextContinuationToken;
     }
-
-    // delete old file or directory with its contents
-    this.delete(oldLocalPath);
-
-    // manually refresh filebrowser contents
-    this._fileBrowserModel!.refresh();
 
     this._fileChanged.emit({
       type: 'rename',
@@ -905,7 +882,7 @@ export class Drive implements Contents.IDrive {
     }
 
     // save file with new content by overwritting existing file
-    await this._s3Client.send(
+    const promise = await this._s3Client.send(
       new PutObjectCommand({
         Bucket: this._name,
         Key: localPath,
@@ -913,6 +890,7 @@ export class Drive implements Contents.IDrive {
         CacheControl: 'no-cache'
       })
     );
+    await Promise.all([promise]);
 
     data = {
       name: fileName,
@@ -926,9 +904,6 @@ export class Drive implements Contents.IDrive {
       writable: true,
       type: fileType
     };
-
-    // manually refresh filebrowser contents
-    this._fileBrowserModel!.refresh();
 
     this._fileChanged.emit({
       type: 'save',
@@ -1019,11 +994,12 @@ export class Drive implements Contents.IDrive {
         await this._s3Client.send(command);
 
       if (Contents) {
-        Contents.forEach(c => {
+        const promises = Contents.map(c => {
           const remainingFilePath = c.Key!.substring(path.length);
           // copy each file from old directory to new location
           this.copy_file(remainingFilePath, path, newFileName, this._name);
         });
+        await Promise.all(promises);
       }
       if (isTruncated) {
         isTruncated = IsTruncated;
@@ -1055,9 +1031,6 @@ export class Drive implements Contents.IDrive {
       writable: true,
       type: fileType
     };
-
-    // manually refresh filebrowser contents
-    this._fileBrowserModel!.refresh();
 
     this._fileChanged.emit({
       type: 'new',
@@ -1114,11 +1087,17 @@ export class Drive implements Contents.IDrive {
         );
         path = isDir ? path + '/' : path;
 
-        Contents.forEach(c => {
+        const promises = Contents.map(async c => {
           const remainingFilePath = c.Key!.substring(path.length);
           // copy each file from old directory to new location
-          this.copy_file(remainingFilePath, path, newFileName, bucketName);
+          await this.copy_file(
+            remainingFilePath,
+            path,
+            newFileName,
+            bucketName
+          );
         });
+        await Promise.all(promises);
 
         const [fileType, fileMimeType, fileFormat] = this.getFileType(
           newFileName.split('.')[1]
@@ -1335,7 +1314,6 @@ export class Drive implements Contents.IDrive {
   private _isDisposed: boolean = false;
   private _disposed = new Signal<this, void>(this);
   private _registeredFileTypes: IRegisteredFileTypes = {};
-  private _fileBrowserModel: FileBrowserModel | undefined;
 }
 
 export namespace Drive {

--- a/src/s3contents.ts
+++ b/src/s3contents.ts
@@ -882,7 +882,7 @@ export class Drive implements Contents.IDrive {
     }
 
     // save file with new content by overwritting existing file
-    const promise = await this._s3Client.send(
+    await this._s3Client.send(
       new PutObjectCommand({
         Bucket: this._name,
         Key: localPath,
@@ -890,7 +890,6 @@ export class Drive implements Contents.IDrive {
         CacheControl: 'no-cache'
       })
     );
-    await Promise.all([promise]);
 
     data = {
       name: fileName,
@@ -997,7 +996,7 @@ export class Drive implements Contents.IDrive {
         const promises = Contents.map(c => {
           const remainingFilePath = c.Key!.substring(path.length);
           // copy each file from old directory to new location
-          this.copy_file(remainingFilePath, path, newFileName, this._name);
+          return this.copy_file(remainingFilePath, path, newFileName, this._name);
         });
         await Promise.all(promises);
       }
@@ -1087,10 +1086,10 @@ export class Drive implements Contents.IDrive {
         );
         path = isDir ? path + '/' : path;
 
-        const promises = Contents.map(async c => {
+        const promises = Contents.map(c => {
           const remainingFilePath = c.Key!.substring(path.length);
           // copy each file from old directory to new location
-          await this.copy_file(
+          return this.copy_file(
             remainingFilePath,
             path,
             newFileName,


### PR DESCRIPTION
This PR makes sure each `S3` operation is finished before the `fileChanged` signal is triggered. This eliminates the need to have the logic to refresh the filebrowser manually.